### PR TITLE
exclude kube-system namespace for gardener maintenance conditions

### DIFF
--- a/.github/create-pr-comment-file.sh
+++ b/.github/create-pr-comment-file.sh
@@ -10,7 +10,7 @@ for env in pr target; do
   for chart in $( ls ); do
     echo ${chart}
     helm dependency update ${chart}
-    for value in $( find ${chart} -type f -name "values-*" ); do
+    for value in $( find ${chart} -type f -name "values*" ); do
       valuefile=$( basename ${value} )
       mkdir -p ../../../out/${env}/${chart}/${valuefile}
       helm template ${chart} -f ${value} --output-dir ../../../out/${env}/${chart}/${valuefile}

--- a/platform-apps/charts/kyverno/values.yaml
+++ b/platform-apps/charts/kyverno/values.yaml
@@ -37,3 +37,5 @@ kyverno:
                     operator: NotIn
                     values:
                       - kyverno
+                      - kube-system
+                  


### PR DESCRIPTION
see https://gardener.cloud/docs/gardener/shoot_status/#constraints and should be also okay for all installations, since kube-system is a very critical system namespace which should work also when kyverno is not reachable