### PR TITLE
use internal service name because external name is encrypted with let…

### DIFF
--- a/platform-apps/charts/k8s-monitoring/values-metalstack.yaml
+++ b/platform-apps/charts/k8s-monitoring/values-metalstack.yaml
@@ -11,12 +11,12 @@ k8s-monitoring:
   
   externalServices:
     prometheus:
-      host: "https://metrics-monitoring-metalstack.platform-engineer.cloud"
+      host: "http://sx-mimir-nginx.mimir.svc"
       queryEndpoint: "/prometheus/api/v1/query"
       writeEndpoint: "/api/v1/push"
       tenantId: ""
     loki:
-      host: "https://logs-monitoring-metalstack.platform-engineer.cloud"
+      host: "http://sx-loki-gateway.loki.svc"
       queryEndpoint: "/loki/api/v1/query"
       writeEndPoint: "/loki/api/v1/push"
       tenantId: ""


### PR DESCRIPTION
…s encryped staging cert which is not trusted out-of-the-box