### PR TITLE
fix unlimited increase in ingester storage usage, because no retentio…

### DIFF
--- a/platform-apps/charts/mimir/values-uibklab.yaml
+++ b/platform-apps/charts/mimir/values-uibklab.yaml
@@ -33,6 +33,8 @@ mimir:
         memory: 12Gi
     persistentVolume:
       size: 50Gi
+    extraArgs:
+      blocks-storage.tsdb.retention-period: 24h
 
 
   minio:


### PR DESCRIPTION
…n-period is set by default. see https://grafana.com/docs/mimir/latest/manage/run-production-environment/production-tips/#ingester-disk-space-requirements