### PR TITLE
Revert "fix unlimited increase in ingester storage usage, because no …

### DIFF
--- a/platform-apps/charts/mimir/values-uibklab.yaml
+++ b/platform-apps/charts/mimir/values-uibklab.yaml
@@ -33,8 +33,6 @@ mimir:
         memory: 12Gi
     persistentVolume:
       size: 50Gi
-    extraArgs:
-      blocks-storage.tsdb.retention-period: 24h
 
 
   minio:


### PR DESCRIPTION
…retention-period is set by default. see https://grafana.com/docs/mimir/latest/manage/run-production-environment/production-tips/#ingester-disk-space-requirements"

This reverts commit 7fae4d18fdef016c5e290e0b43a9722caab708d4.