### PR TITLE
fix(testkube): disable cypress tests due to full filesystem in GitHub…

### DIFF
--- a/platform-apps/charts/testkube/templates/kind-portal-tests.yaml
+++ b/platform-apps/charts/testkube/templates/kind-portal-tests.yaml
@@ -33,7 +33,7 @@ kind: TestWorkflow
 metadata:
   name: kind-portal-cypress
   labels:
-    type: kind-portal
+    type: kind-portal-not-used
 spec:
   content:
     git:


### PR DESCRIPTION
… runners

Run only playwright tests