### PR TITLE
fix(mimir): Add container security context to Minio configuration

### DIFF
--- a/platform-apps/charts/mimir/values-kubrix-default.yaml
+++ b/platform-apps/charts/mimir/values-kubrix-default.yaml
@@ -36,6 +36,8 @@ mimir:
       size: 5Gi
 
   minio:
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
     persistence:
       size: 10Gi
 


### PR DESCRIPTION
fixes startup problems on AKS when gatekeeper policies are acive

```
Error creating: admission webhook "validation.gatekeeper.sh" denied the request: [azurepolicy-k8sazurev3noprivilegeescalatio-456dd346b5006f0ecdd7] Privilege escalation container is not allowed: minio
```